### PR TITLE
Implement API endpoints for Building Search

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -21,7 +21,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String courseId );
     
      @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, {'section.timeLocations.0.building': { $regex: ?2 } }")
-     Optional<ConvertedSection> findByQuarterRangeAndBuildingName(
+     List<ConvertedSection> findByQuarterRangeAndBuildingName(
         String startQuarter, 
         String endQuarter, 
         String building );

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -14,10 +14,15 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
     @Query("{'courseInfo.quarter': ?0, 'section.enrollCode': ?1}")
     Optional<ConvertedSection> findOneByQuarterAndEnrollCode(String quarter, String enrollCode);
 
-    @Query("{'courseInfo.quarter': {$gte: ?0, $lte: ?1}, 'courseInfo.courseId': { $regex: ?2 }}")
+    @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'courseInfo.courseId': { $regex: ?2 } }")
     List<ConvertedSection> findByQuarterRangeAndCourseId(
         String startQuarter,
         String endQuarter,
         String courseId );
     
+     @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, {'section.timeLocations.0.building': { $regex: ?2 } }")
+     Optional<ConvertedSection> findByQuarterRangeAndBuildingName(
+        String startQuarter, 
+        String endQuarter, 
+        String building );
 }

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -20,7 +20,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String endQuarter,
         String courseId );
     
-     @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, {'section.timeLocations.0.building': { $regex: ?2 } }")
+     @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.0.building': { $regex: ?2, $options: 'i' } }")
      List<ConvertedSection> findByQuarterRangeAndBuildingName(
         String startQuarter, 
         String endQuarter, 

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -20,7 +20,7 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String endQuarter,
         String courseId );
     
-     @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.0.building': { $regex: ?2, $options: 'i' } }")
+     @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
      List<ConvertedSection> findByQuarterRangeAndBuildingName(
         String startQuarter, 
         String endQuarter, 

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -21,8 +21,8 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
         String courseId );
     
      @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'section.timeLocations.building': { $regex: ?2, $options: 'i' } }")
-     List<ConvertedSection> findByQuarterRangeAndBuildingName(
+     List<ConvertedSection> findByQuarterRangeAndBuildingCode(
         String startQuarter, 
         String endQuarter, 
-        String building );
+        String buildingCode );
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -29,17 +29,17 @@ public class CourseOverTimeBuildingController {
     @Autowired
     ConvertedSectionCollection convertedSectionCollection;
 
-    @ApiOperation(value = "Get a list of courses over time, filtered by (abbreviated) building name")
+    @ApiOperation(value = "Get a list of courses over time, filtered by (abbreviated) building code (e.g. 'GIRV' for Girvetz Hall)")
     @GetMapping(value = "/buildingsearch", produces = "application/json")
     public ResponseEntity<String> search(
         @RequestParam String startQtr,
         @RequestParam String endQtr,
-        @RequestParam String buildingName
+        @RequestParam String buildingCode
     ) throws JsonProcessingException {
-        List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndBuildingName(
+        List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndBuildingCode(
             startQtr,
             endQtr,
-            buildingName
+            buildingCode
         );
         String body = mapper.writeValueAsString(courseResults);
         return ResponseEntity.ok().body(body);

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -29,7 +29,7 @@ public class CourseOverTimeBuildingController {
     @Autowired
     ConvertedSectionCollection convertedSectionCollection;
 
-    @ApiOperation(value = "Get a list of courses over time, filtered by building name")
+    @ApiOperation(value = "Get a list of courses over time, filtered by (abbreviated) building name")
     @GetMapping(value = "/buildingsearch", produces = "application/json")
     public ResponseEntity<String> search(
         @RequestParam String startQtr,

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -1,0 +1,47 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import java.util.List;
+
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import io.swagger.annotations.ApiOperation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@RestController
+@RequestMapping("/api/public/courseovertime")
+public class CourseOverTimeBuildingController {
+
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeBuildingController.class);
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ConvertedSectionCollection convertedSectionCollection;
+
+    @ApiOperation(value = "Get a list of courses over time, filtered by building name")
+    @GetMapping(value = "/buildingsearch", produces = "application/json")
+    public ResponseEntity<String> search(
+        @RequestParam String startQtr,
+        @RequestParam String endQtr,
+        @RequestParam String buildingName
+    ) throws JsonProcessingException {
+        List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndBuildingName(
+            startQtr,
+            endQtr,
+            buildingName
+        );
+        String body = mapper.writeValueAsString(courseResults);
+        return ResponseEntity.ok().body(body);
+    }    
+}

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.annotations.ApiParam;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -29,11 +31,29 @@ public class CourseOverTimeBuildingController {
     @Autowired
     ConvertedSectionCollection convertedSectionCollection;
 
-    @ApiOperation(value = "Get a list of courses over time, filtered by (abbreviated) building code (e.g. 'GIRV' for Girvetz Hall)")
+    @ApiOperation(value = "Get a list of courses over time, filtered by (abbreviated) building code")
     @GetMapping(value = "/buildingsearch", produces = "application/json")
     public ResponseEntity<String> search(
+        @ApiParam(
+            name =  "startQtr",
+            type = "String",
+            value = "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+            example = "20231",
+            required = true)
         @RequestParam String startQtr,
+        @ApiParam(
+            name =  "endQtr",
+            type = "String",
+            value = "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+            example = "20231",
+            required = true)
         @RequestParam String endQtr,
+        @ApiParam(
+            name =  "buildingCode",
+            type = "String",
+            value = "Building code such as PHELP for Phelps, GIRV for Girvetz",
+            example = "GIRV",
+            required = true)
         @RequestParam String buildingCode
     ) throws JsonProcessingException {
         List<ConvertedSection> courseResults = convertedSectionCollection.findByQuarterRangeAndBuildingCode(

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -1,0 +1,113 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.Section;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@WebMvcTest(value = CourseOverTimeBuildingController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class CourseOverTimeBuildingControllerTests {
+    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeBuildingControllerTests.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    ConvertedSectionCollection convertedSectionCollection;
+    @Test
+    public void test_search_emptyRequest() throws Exception {
+        List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
+        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingName=%s";
+        
+        String url = String.format(urlTemplate, "20221", "20222", "Storke Tower");
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndBuildingName(any(String.class), any(String.class), any(String.class)))
+            .thenReturn(expectedResult);
+
+        // act
+        MvcResult response = mockMvc.perform(
+            get(url).contentType("application/json")
+        ).andExpect(
+            status().isOk()
+        ).andReturn();
+
+
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        String expectedString = mapper.writeValueAsString(expectedResult);
+        
+        assertEquals(expectedString, responseString);
+    }
+
+    @Test public void test_search_validRequestWithoutSuffix() throws Exception {
+        CourseInfo info = CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
+        
+        Section section1 = new Section();
+
+        Section section2 = new Section();
+
+        ConvertedSection cs1 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section1)
+            .build();
+        
+        ConvertedSection cs2 = ConvertedSection.builder()
+            .courseInfo(info)
+            .section(section2)
+            .build();
+
+        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingName=%s";
+        
+        String url = String.format(urlTemplate, "20221", "20222", "GIRV");
+
+        List<ConvertedSection> expectedSecs = new ArrayList<ConvertedSection>();
+        expectedSecs.addAll(Arrays.asList(cs1, cs2));
+
+        // mock
+        when(convertedSectionCollection.findByQuarterRangeAndBuildingName(any(String.class), any(String.class), eq("GIRV"))).thenReturn(expectedSecs);
+
+        // act
+        MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+
+        // assert
+        String expectedString = "{expectedJSONResult}";
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedString, responseString);
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -105,7 +105,7 @@ public class CourseOverTimeBuildingControllerTests {
         MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
 
         // assert
-        String expectedString = "{expectedJSONResult}";
+        String expectedString = mapper.writeValueAsString(expectedSecs);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedString, responseString);
     }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -46,12 +46,12 @@ public class CourseOverTimeBuildingControllerTests {
     @Test
     public void test_search_emptyRequest() throws Exception {
         List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
-        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingName=%s";
+        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingCode=%s";
         
         String url = String.format(urlTemplate, "20221", "20222", "Storke Tower");
 
         // mock
-        when(convertedSectionCollection.findByQuarterRangeAndBuildingName(any(String.class), any(String.class), any(String.class)))
+        when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(any(String.class), any(String.class), any(String.class)))
             .thenReturn(expectedResult);
 
         // act
@@ -91,7 +91,7 @@ public class CourseOverTimeBuildingControllerTests {
             .section(section2)
             .build();
 
-        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingName=%s";
+        String urlTemplate = "/api/public/courseovertime/buildingsearch?startQtr=%s&endQtr=%s&buildingCode=%s";
         
         String url = String.format(urlTemplate, "20221", "20222", "GIRV");
 
@@ -99,7 +99,7 @@ public class CourseOverTimeBuildingControllerTests {
         expectedSecs.addAll(Arrays.asList(cs1, cs2));
 
         // mock
-        when(convertedSectionCollection.findByQuarterRangeAndBuildingName(any(String.class), any(String.class), eq("GIRV"))).thenReturn(expectedSecs);
+        when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(any(String.class), any(String.class), eq("GIRV"))).thenReturn(expectedSecs);
 
         // act
         MvcResult response = mockMvc.perform(get(url)).andExpect(status().isOk()).andReturn();


### PR DESCRIPTION
In this PR I implemented the API endpoints for filtering by building name. Currently it will return all sections and lectures that are in a given building, but this PR only concerns the API endpoints for future functionalities, such as filtering by only lectures. Tests are also added where needed, and mutation and coverage tests pass.

Example usage:

![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/86684516/7e6a88ff-1ab8-4b2f-b4d0-40e55f9d7099)
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/86684516/2450d8d7-9d44-4c2f-8bfc-525dbf876313)
