### PR TITLE
hx -Break one : added upload history grade services and all needed models

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
             <artifactId>spring-security-config</artifactId>
         </dependency>
 
+          <!-- http://opencsv.sourceforge.net/ -->
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.7.1</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -242,6 +248,7 @@
                         <avoidCallsTo>org.apache.log4j</avoidCallsTo>
                         <avoidCallsTo>org.slf4j</avoidCallsTo>
                         <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
+                        <avoidCallsTo>com.opencsv.CSVReader</avoidCallsTo>
                     </avoidCallsTo>
                     <timestampedReports>false</timestampedReports>
                 </configuration>

--- a/src/main/java/edu/ucsb/cs156/courses/entities/GradeHistory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/entities/GradeHistory.java
@@ -27,18 +27,29 @@ import lombok.Builder;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Entity(name = "gradehistory")
-@Table(uniqueConstraints = { @UniqueConstraint(name = "UniqueGradeHistory", columnNames = { "year", "quarter", "subjectArea","course","instructor","gradeGiven","sumofStudentCount" }) })
+
+@Entity(name = "historygrade")
+@Table(uniqueConstraints = { @UniqueConstraint(name = "UniqueGradeHistory", columnNames = { "yyyyq", "course","instructor","grade","count"}) })
+
 public class GradeHistory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String year;
-    private String quarter;
-    private String level;
-    private String subjectArea;
+    private String yyyyq;
     private String course;
     private String instructor;
-    private String gradeGiven;
-    private int sumofStudentCount;
+    private String grade;
+    private int count;
+
+    public String getSubjectArea() {
+        if (course==null)
+            return null;
+        return course.substring(0, 8).trim();
+    }
+    public String getCourseNum() {
+        if (course==null)
+            return null;
+        return course.substring(8).trim();
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/courses/models/ApiResult.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/ApiResult.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.courses.models.github;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResult {
+    private String sha;
+    private String url;
+    private List<TreeElement> tree;
+    private Boolean truncated;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/models/TreeElement.java
+++ b/src/main/java/edu/ucsb/cs156/courses/models/TreeElement.java
@@ -1,0 +1,20 @@
+package edu.ucsb.cs156.courses.models.github;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TreeElement {
+    private String path;
+    private String mode;
+    private String type;
+    private String sha;
+    private int size;
+    private String url;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/repositories/GradeHistoryRepository.java
+++ b/src/main/java/edu/ucsb/cs156/courses/repositories/GradeHistoryRepository.java
@@ -2,10 +2,16 @@ package edu.ucsb.cs156.courses.repositories;
 
 import edu.ucsb.cs156.courses.entities.GradeHistory;
 
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GradeHistoryRepository extends CrudRepository<GradeHistory, Long> {
+    public List<GradeHistory> findByYyyyqAndCourseAndInstructorAndGrade(String yyyyq, String course, String instructor, String grade);
+    public List<GradeHistory> findByCourse(String course);
 
 }

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryService.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.courses.services;
+
+import java.io.Reader;
+import java.util.List;
+
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+
+public interface UCSBGradeHistoryService {
+    public List<String> getUrls() throws Exception;
+    public List<GradeHistory> getGradeData(String url) throws Exception;
+    public List<GradeHistory> parse(Reader reader) throws Exception;
+}

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceImpl.java
@@ -1,0 +1,110 @@
+package edu.ucsb.cs156.courses.services;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVReader;
+
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.models.Quarter;
+import edu.ucsb.cs156.courses.models.github.ApiResult;
+import edu.ucsb.cs156.courses.models.github.TreeElement;
+
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service("UCSBGradeHistoryService")
+@Slf4j
+public class UCSBGradeHistoryServiceImpl implements UCSBGradeHistoryService {
+
+    private final RestTemplate restTemplate;
+
+    public UCSBGradeHistoryServiceImpl(RestTemplateBuilder restTemplateBuilder) {
+        restTemplate = restTemplateBuilder.build();
+    }
+
+    @Autowired
+    ObjectMapper mapper;
+
+    public static final String REPO_OWNER_AND_NAME = "ucsb-cs156/UCSB_Grades";
+    public static final String API_ENDPOINT = "https://api.github.com/repos/"
+            + REPO_OWNER_AND_NAME +
+            "/git/trees/main?recursive=1";
+
+    @Override
+    public List<String> getUrls() throws Exception {
+
+        log.info("getting data from {}", API_ENDPOINT);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        Map<String, String> uriVariables = Map.of("recursive", "1");
+
+        ResponseEntity<String> re = restTemplate.exchange(API_ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+
+        ApiResult apiResult = mapper.readValue(re.getBody(), ApiResult.class);
+
+        List<TreeElement> treeElements = apiResult.getTree();
+        List<String> urls = treeElements.stream().map(treeElement -> treeElement.getPath())
+                .filter(path -> (path.startsWith("quarters/") && path.endsWith(".csv"))).collect(Collectors.toList());
+        List<String> rawUrls = urls.stream()
+                .map(url -> "https://raw.githubusercontent.com/" + REPO_OWNER_AND_NAME + "/main/" + url)
+                .collect(Collectors.toList());
+        return rawUrls;
+    }
+
+    @Override
+    public List<GradeHistory> getGradeData(String url) throws Exception {
+        log.info("getting data from {}", url);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        String csvData = re.getBody();
+        return parse(new StringReader(csvData));
+    }
+
+    @Override
+    public List<GradeHistory> parse(Reader reader) throws Exception {
+        List<GradeHistory> gradeHistoryList = new ArrayList<GradeHistory>();
+        log.info("Parsing CSV file with grade history... ");
+        CSVReader csvReader = new CSVReader(reader);
+        csvReader.skip(1);
+        List<String[]> myEntries = csvReader.readAll();
+        for (String[] row : myEntries) {
+            String yyyyq = Integer.toString(Quarter.qyyToyyyyQ(row[0]));
+            GradeHistory gradeHistory = GradeHistory.builder()
+                    .yyyyq(yyyyq)
+                    .course(row[2])
+                    .instructor(row[3])
+                    .grade(row[4])
+                    .count(Integer.parseInt(row[5]))
+                    .build();
+            log.info("Parsed: " + gradeHistory.toString());
+            gradeHistoryList.add(gradeHistory);
+        }
+        csvReader.close();
+        return gradeHistoryList;
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/entities/GradeHistoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/entities/GradeHistoryTests.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.courses.entities;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GradeHistoryTests {
+    @Test
+    public void test_getSubjectArea_and_getCourseNum_CMPSC_130A() throws Exception {
+        GradeHistory gh = GradeHistory.builder()
+            .course("CMPSC   130A")
+            .build();
+        assertEquals("CMPSC", gh.getSubjectArea());
+        assertEquals("130A", gh.getCourseNum());
+    }
+
+    @Test
+    public void test_getSubjectArea_and_getCourseNum_null() throws Exception {
+        GradeHistory gh = GradeHistory.builder()
+            .course(null)
+            .build();
+        assertNull(gh.getSubjectArea());
+        assertNull(gh.getCourseNum());
+    } 
+}

--- a/src/test/java/edu/ucsb/cs156/courses/fixtures/GradeHistoryFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/fixtures/GradeHistoryFixtures.java
@@ -1,0 +1,74 @@
+package edu.ucsb.cs156.courses.fixtures;
+
+public class GradeHistoryFixtures {
+    public static final String GITHUB_API_SAMPLE_JSON = """
+        {
+            "sha": "c5535a56190265628f39b84702f51b4aa73edb73",
+            "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/trees/c5535a56190265628f39b84702f51b4aa73edb73",
+            "tree": [
+              {
+                "path": ".gitignore",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "b296010c8302bfc9179113f9f422612594d94685",
+                "size": 18,
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/blobs/b296010c8302bfc9179113f9f422612594d94685"
+              },
+              {
+                "path": "README.md",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "dcf7a0ec30a49c335d8f1458b4c4c347be52706a",
+                "size": 639,
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/blobs/dcf7a0ec30a49c335d8f1458b4c4c347be52706a"
+              },
+              {
+                "path": "UCSB Grades.csv",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "499ef6093be9b35057e68c0e80e549d71a06a119",
+                "size": 18869547,
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/blobs/499ef6093be9b35057e68c0e80e549d71a06a119"
+              },
+              {
+                "path": "make_csvs.py",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "045edc988872819a2dae51967103e6deac384c7a",
+                "size": 3950,
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/blobs/045edc988872819a2dae51967103e6deac384c7a"
+              },
+              {
+                "path": "quarters",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "8d79f603ad8e2bb38802b31457ed052a8d431c72",
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/trees/8d79f603ad8e2bb38802b31457ed052a8d431c72"
+              },
+              {
+                "path": "quarters/F09",
+                "mode": "040000",
+                "type": "tree",
+                "sha": "61090a24c0504aedf4bb61095af03b66aa8b5e16",
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/trees/61090a24c0504aedf4bb61095af03b66aa8b5e16"
+              },
+              {
+                "path": "quarters/F09/ANTH.csv",
+                "mode": "100644",
+                "type": "blob",
+                "sha": "1e0a1ba0f8601a13fdfec662af2dbc1def33506c",
+                "size": 4381,
+                "url": "https://api.github.com/repos/ucsb-cs156/UCSB_Grades/git/blobs/1e0a1ba0f8601a13fdfec662af2dbc1def33506c"
+              }
+            ]
+        }
+    """;
+
+    public static final String SAMPLE_CSV_FILE_CONTENTS="""
+        Quarter,Course Level,Course,Instructor,Grade Given,Sum of Student Count
+        F09,Undergraduate,DANCE    47A,HUSTON V G,A-,3
+        F09,Undergraduate,DANCE    47A,HUSTON V G,C+,1
+        F09,Undergraduate,DANCE    51,STUNKEL M C,A,8
+        F09,Undergraduate,DANCE    51,STUNKEL M C,B-,1
+        """;
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceTests.java
@@ -1,0 +1,103 @@
+package edu.ucsb.cs156.courses.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.fixtures.GradeHistoryFixtures;
+
+@RestClientTest(UCSBGradeHistoryServiceImpl.class)
+@AutoConfigureDataJpa
+public class UCSBGradeHistoryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private UCSBGradeHistoryService ucsbGradeHistoryService;
+
+    @Test
+    public void test_getUrls() throws Exception {
+        String expectedURL = UCSBGradeHistoryServiceImpl.API_ENDPOINT;
+
+        List<String> EXPECTED_URLS = new ArrayList<String>();
+        EXPECTED_URLS.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F09/ANTH.csv");
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(GradeHistoryFixtures.GITHUB_API_SAMPLE_JSON, MediaType.APPLICATION_JSON));
+
+        List<String> result = ucsbGradeHistoryService.getUrls();
+
+        assertEquals(EXPECTED_URLS, result);
+    }
+
+    @Test
+    public void test_getGradeData() throws Exception {
+        String url = "https://example.org/getGradeData";
+
+        List<GradeHistory> expectedResult = new ArrayList<GradeHistory>();
+        expectedResult.add(
+            GradeHistory.builder()
+            .yyyyq("20094")
+            .course("DANCE    47A")
+            .instructor("HUSTON V G")
+            .grade("A-")
+            .count(3)
+            .build());
+        expectedResult.add(
+                GradeHistory.builder()
+                .yyyyq("20094")
+                .course("DANCE    47A")
+                .instructor("HUSTON V G")
+                .grade("C+")
+                .count(1)
+                .build());
+        expectedResult.add(
+                    GradeHistory.builder()
+                    .yyyyq("20094")
+                    .course("DANCE    51")
+                    .instructor("STUNKEL M C")
+                    .grade("A")
+                    .count(8)
+                    .build());
+        expectedResult.add(
+                        GradeHistory.builder()
+                        .yyyyq("20094")
+                        .course("DANCE    51")
+                        .instructor("STUNKEL M C")
+                        .grade("B-")
+                        .count(1)
+                        .build());
+
+        this.mockRestServiceServer.expect(requestTo(url))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(GradeHistoryFixtures.SAMPLE_CSV_FILE_CONTENTS, MediaType.APPLICATION_JSON));
+
+        List<GradeHistory> actualResult = ucsbGradeHistoryService.getGradeData(url);
+
+        assertEquals(expectedResult, actualResult);
+    }
+
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/services/UCSBGradeHistoryServiceTests.java
@@ -52,7 +52,7 @@ public class UCSBGradeHistoryServiceTests {
 
     @Test
     public void test_getGradeData() throws Exception {
-        String url = "https://example.org/getGradeData";
+        String url = "https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F09/DANCE.csv";
 
         List<GradeHistory> expectedResult = new ArrayList<GradeHistory>();
         expectedResult.add(


### PR DESCRIPTION
In this PR, I slightly changed the name of variables in gradehistory entity and added more functions for both gradehistory entity and repository. Also, I added uploading history grade services that can convert the csvs files, related packages in the pom.xml, and needed models . Finish adding all required test files of above things. 