### PR TITLE
in - Bug Fix Remove +/- Button for Basic Course Search where not needed

### DIFF
--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -47,7 +47,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
                     >
-                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null}
+                    {row.subRows.length >= 2 ? row.isExpanded ? "➖ " : "➕ " : null}
                     </span>{" "}
                     {cell.render("Cell")} 
                     </>

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -49,7 +49,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 
-                    // Stryker enable all
+                    // Stryker restore all
                     // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -45,7 +45,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`} 
                     > 
-                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null} 
+                    {  ( row.subRows.length > 1  ) ? ( row.isExpanded ? "➖ " : "➕ " ) : null} 
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -38,19 +38,19 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    // Stryker disable next-line ObjectLiteral
+                    // Stryker disable all
                     style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
-                    
                     {cell.isGrouped ? (
                     <>
                     <span {...row.getToggleRowExpandedProps()}
-                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
-                    >
-                    {row.subRows.length >= 2 ? row.isExpanded ? "➖ " : "➕ " : null}
-                    </span>{" "}
+                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`} 
+                    > 
+                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null} 
+                    </span>{" "} 
                     {cell.render("Cell")} 
-                    </>
+                    </> 
+                    // Stryker enable all
                     // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -33,7 +33,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
             {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
-                
                 return (
                     <td
                     {...cell.getCellProps()}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -33,6 +33,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
             {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
+                
                 return (
                     <td
                     {...cell.getCellProps()}
@@ -46,10 +47,11 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
                     >
-                    {row.isExpanded ? "➖ " : "➕ "}
+                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null}
                     </span>{" "}
                     {cell.render("Cell")} 
                     </>
+                    // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -50,7 +50,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     {cell.render("Cell")} 
                     </> 
                     // Stryker restore all
-                    // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -37,7 +37,8 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    // Stryker disable all
+                    // Stryker disable next-line ObjectLiteral
+                    // Stryker disable next-line EqualityOperator
                     style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     {cell.isGrouped ? (
@@ -49,7 +50,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 
-                    // Stryker restore all
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")


### PR DESCRIPTION
Updated SectionsTableBase.js to remove the button that shows +/- when there is no associated sections with it.

Note: Used rows.subRows.length > 1 instead of canExpand/depth and other implementations since they don't work as intended.
Note: rows.subRows.length > 1 because each row has 1 empty subRow 

# Storybook
- [Before](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/storybook/?path=/docs/components-sections-sectionstable--empty)
- [After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/37/storybook/?path=/docs/components-sections-sectionstable--empty)

# Screenshots
### Before
MATH 101B has no sections but the plus button can be clicked:
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/f10af51c-4e05-4252-8f1b-02010e2e1c5b)

### After
Classes without sections no longer have the button:
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/4c056f6f-8d47-48d9-8d60-5275c4d38da6)
