### PR TITLE
yl - Create form component for instructor-based search

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
@@ -25,11 +25,11 @@ const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
   const localStartQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.StartQuarter");
   const localEndQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.EndQuarter");
   const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
-  // Stryker restore all
 
   const [startQuarter, setStartQuarter] = useState(localStartQuarter || quarters[0].yyyyq);
   const [endQuarter, setEndQuarter] = useState(localEndQuarter || quarters[0].yyyyq);
   const [instructor, setInstructor] = useState(localInstructor || "");
+  // Stryker restore all
 
   const handleSubmit = (event) => {
     event.preventDefault();

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { Form, Button, Container, Row, Col } from "react-bootstrap";
+
+//import { allTheLevels } from "fixtures/levelsFixtures";
+import { quarterRange } from "main/utils/quarterUtilities";
+
+import { useSystemInfo } from "main/utils/systemInfo";
+import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
+// import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
+//import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
+// import { useBackend  } from "main/utils/useBackend";
+
+const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
+
+  const { data: systemInfo } = useSystemInfo();
+
+  // Stryker disable OptionalChaining
+  const startQtr = systemInfo?.startQtrYYYYQ || "20211";
+  const endQtr = systemInfo?.endQtrYYYYQ || "20214";
+  // Stryker restore OptionalChaining
+
+  const quarters = quarterRange(startQtr, endQtr);
+
+  // Stryker disable all : not sure how to test/mock local storage
+  const localStartQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.StartQuarter");
+  const localEndQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.EndQuarter");
+  const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
+
+  const [startQuarter, setStartQuarter] = useState(localStartQuarter || quarters[0].yyyyq);
+  const [endQuarter, setEndQuarter] = useState(localEndQuarter || quarters[0].yyyyq);
+  const [instructor, setInstructor] = useState(localInstructor || "");
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    fetchJSON(event, { startQuarter, endQuarter, instructor });
+  };
+
+  const handleInstructorOnChange = (event) => {
+    setInstructor(event.target.value);
+};
+
+
+  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Container>
+        <Row>
+          <Col md="auto">
+            <SingleQuarterDropdown
+              quarters={quarters}
+              quarter={startQuarter}
+              setQuarter={setStartQuarter}
+              controlId={"CourseOverTimeInstructorSearch.StartQuarter"}
+              label={"Start Quarter"}
+            />
+          </Col>
+          <Col md="auto">
+            <SingleQuarterDropdown
+              quarters={quarters}
+              quarter={endQuarter}
+              setQuarter={setEndQuarter}
+              controlId={"CourseOverTimeInstructorSearch.EndQuarter"}
+              label={"End Quarter"}
+            />
+          </Col>
+        </Row>
+        <Form.Group controlId="CourseOverTimeInstructorSearch.Instructor">
+            <Form.Label>Instructor Name</Form.Label>
+            <Form.Control onChange={handleInstructorOnChange} defaultValue={instructor} />
+        </Form.Group>
+        <Row style={{ paddingTop: 10, paddingBottom: 10 }}>
+          <Col md="auto">
+            <Button variant="primary" type="submit">
+              Submit
+            </Button>
+          </Col>
+        </Row>
+      </Container>
+    </Form>
+  );
+};
+
+export default CourseOverTimeInstructorSearchForm;

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
@@ -25,6 +25,7 @@ const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
   const localStartQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.StartQuarter");
   const localEndQuarter = localStorage.getItem("CourseOverTimeInstructorSearch.EndQuarter");
   const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
+  // Stryker restore all
 
   const [startQuarter, setStartQuarter] = useState(localStartQuarter || quarters[0].yyyyq);
   const [endQuarter, setEndQuarter] = useState(localEndQuarter || quarters[0].yyyyq);
@@ -39,8 +40,6 @@ const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
     setInstructor(event.target.value);
 };
 
-
-  // Stryker disable all : Stryker is testing by changing the padding to 0. But this is simply a visual optimization as it makes it look better
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.js
@@ -1,14 +1,8 @@
 import { useState } from "react";
 import { Form, Button, Container, Row, Col } from "react-bootstrap";
-
-//import { allTheLevels } from "fixtures/levelsFixtures";
 import { quarterRange } from "main/utils/quarterUtilities";
-
 import { useSystemInfo } from "main/utils/systemInfo";
 import SingleQuarterDropdown from "../Quarters/SingleQuarterDropdown";
-// import SingleSubjectDropdown from "../Subjects/SingleSubjectDropdown";
-//import SingleLevelDropdown from "../Levels/SingleLevelDropdown";
-// import { useBackend  } from "main/utils/useBackend";
 
 const CourseOverTimeInstructorSearchForm = ({ fetchJSON }) => {
 

--- a/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
@@ -1,0 +1,35 @@
+//TODO: Backend API?
+
+import React from "react";
+
+import CourseOverTimeInstructorSearchForm from "main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+
+export default {
+  title: "components/BasicCourseSearch/CourseOverTimeInstructorSearch",
+  component: CourseOverTimeInstructorSearchForm,
+  parameters: {
+    mockData: [
+      {
+        url: '/api/systemInfo',
+        method: 'GET',
+        status: 200,
+        response: systemInfoFixtures.showingBothStartAndEndQtr
+      },
+    ],
+  },
+};
+
+const Template = (args) => {
+  return <CourseOverTimeInstructorSearchForm {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  submitText: "Create",
+  fetchJSON: (_event, data) => {
+    console.log("Submit was clicked, data=", data);
+  }
+};

--- a/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
@@ -26,7 +26,6 @@ const Template = (args) => {
 export const Default = Template.bind({});
 
 Default.args = {
-  submitText: "Create",
   fetchJSON: (_event, data) => {
     console.log("Submit was clicked, data=", data);
   }

--- a/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
+++ b/frontend/src/stories/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.stories.js
@@ -1,5 +1,3 @@
-//TODO: Backend API?
-
 import React from "react";
 
 import CourseOverTimeInstructorSearchForm from "main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm";

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
@@ -54,21 +54,7 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
         </MemoryRouter>
       </QueryClientProvider>
     );
-  });
-
-  test("Before I select a start quarter, the state for start quarter is initialized", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CourseOverTimeSearchForm />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-    const selectStartQuarter = screen.getByLabelText("Start Quarter");
-    expect(selectStartQuarter.value).toBe("20201");
-  });
-
-  
+  });  
 
   test("when I select a start quarter, the state for start quarter changes", () => {
     render(
@@ -219,17 +205,5 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     const buttonRow = buttonCol.parentElement;
     expect(buttonRow).toHaveAttribute("style", "padding-top: 10px; padding-bottom: 10px;");
   });
-
-  test("Before I select an instructor name, the state for instructor name is initialized", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <CourseOverTimeSearchForm />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-    const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
-    const selectStartQuarter = screen.getByLabelText("Instructor Name");
-    expect(selectStartQuarter.value).toBe(localInstructor);
-  });
+  
 });

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
@@ -1,0 +1,195 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { toast } from "react-toastify";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import CourseOverTimeSearchForm from "main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm";
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+}));
+
+describe("CourseOverTimeInstructorSearchForm tests", () => {
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const queryClient = new QueryClient();
+  const addToast = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, {
+        ...systemInfoFixtures.showingNeither,
+        "startQtrYYYYQ": "20201",
+        "endQtrYYYYQ": "20214"
+      });
+
+    toast.mockReturnValue({
+      addToast: addToast,
+    });
+  });
+
+
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  test("when I select a start quarter, the state for start quarter changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20201");
+    expect(selectStartQuarter.value).toBe("20201");
+  });
+
+  test("when I select an end quarter, the state for end quarter changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20204");
+    expect(selectEndQuarter.value).toBe("20204");
+  });
+
+  test("when I select an instructor name, the state for instructor name changes", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectInstructor = screen.getByLabelText("Instructor Name");
+    userEvent.type(selectInstructor, "conrad");
+    expect(selectInstructor.value).toBe("conrad");
+  });
+
+  test("when I click submit, the right stuff happens", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+    };
+
+    const fetchJSONSpy = jest.fn();
+
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const expectedFields = {
+      startQuarter: "20211",
+      endQuarter: "20214",
+      instructor: "CONRAD",
+    };
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20211");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20214");
+    const selectInstructor = screen.getByLabelText("Instructor Name");
+    userEvent.type(selectInstructor, "CONRAD");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+
+    await waitFor(() => expect(fetchJSONSpy).toHaveBeenCalledTimes(1));
+
+    expect(fetchJSONSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      expectedFields
+    );
+  });
+
+  test("when I click submit when JSON is EMPTY, setCourse is not called!", async () => {
+    axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+
+    const sampleReturnValue = {
+      sampleKey: "sampleValue",
+      total: 0,
+    };
+
+    const fetchJSONSpy = jest.fn();
+
+    fetchJSONSpy.mockResolvedValue(sampleReturnValue);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm fetchJSON={fetchJSONSpy} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    userEvent.selectOptions(selectStartQuarter, "20204");
+    const selectEndQuarter = screen.getByLabelText("End Quarter");
+    userEvent.selectOptions(selectEndQuarter, "20204");
+    const selectInstructor = screen.getByLabelText("Instructor Name");
+    userEvent.type(selectInstructor, "conrad");
+    const submitButton = screen.getByText("Submit");
+    userEvent.click(submitButton);
+  });
+
+
+  test("renders without crashing when fallback values are used", async () => {
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": false,
+        "startQtrYYYYQ": null, // use fallback value
+        "endQtrYYYYQ": null  // use fallback value
+      });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Make sure the first and last options 
+    expect(await screen.findByTestId(/CourseOverTimeInstructorSearch.StartQuarter-option-0/)).toHaveValue("20211")
+    expect(await screen.findByTestId(/CourseOverTimeInstructorSearch.StartQuarter-option-3/)).toHaveValue("20214")
+
+  });
+
+});

--- a/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
+++ b/frontend/src/tests/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm.test.js
@@ -56,6 +56,20 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
     );
   });
 
+  test("Before I select a start quarter, the state for start quarter is initialized", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const selectStartQuarter = screen.getByLabelText("Start Quarter");
+    expect(selectStartQuarter.value).toBe("20201");
+  });
+
+  
+
   test("when I select a start quarter, the state for start quarter changes", () => {
     render(
       <QueryClientProvider client={queryClient}>
@@ -192,4 +206,30 @@ describe("CourseOverTimeInstructorSearchForm tests", () => {
 
   });
 
+  test("Button padding is correct", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const submitButton = screen.getByText("Submit");
+    const buttonCol = submitButton.parentElement;
+    const buttonRow = buttonCol.parentElement;
+    expect(buttonRow).toHaveAttribute("style", "padding-top: 10px; padding-bottom: 10px;");
+  });
+
+  test("Before I select an instructor name, the state for instructor name is initialized", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseOverTimeSearchForm />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    const localInstructor = localStorage.getItem("CourseOverTimeInstructorSearch.Instructor");
+    const selectStartQuarter = screen.getByLabelText("Instructor Name");
+    expect(selectStartQuarter.value).toBe(localInstructor);
+  });
 });


### PR DESCRIPTION
In this PR, we add a new frontend form component that allows for instructor-based search.

This component is modeled after the existing CourseOverTimeSearchForm component, and is one part of a larger PR at #38 that is now closed.

# Storybook
[The new component](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/42/storybook/?path=/docs/components-basiccoursesearch-courseovertimeinstructorsearch--default)

# Screenshots
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/b95baaa0-ff0e-4b6f-9a7b-53d841b0e878)


Merging this PR closes #41.