### PR TITLE
kt - Add files for dropdown menu (Building Search 1/3)

### DIFF
--- a/frontend/src/fixtures/buildingFixtures.js
+++ b/frontend/src/fixtures/buildingFixtures.js
@@ -1,0 +1,152 @@
+export const allBuildings = [["", ""],
+                             ["ARTS", "Arts Building"],
+                             ["BIOEN", "Bioengineering"],
+                             ["BRDA", "Broida Hall"],
+                             ["BREN", "Bren Hall"],
+                             ["BSIF", "Bio Science Instructional Facility"],
+                             ["BUCHN", "Buchanan Hall"],
+                             ["CAMPB", "Campbell Hall"],
+                             ["CHEM", "Chemistry"],
+                             ["CRST", "College of Creative Studies"],
+                             ["ED", "Education"],
+                             ["ELLSN", "Ellison Hall"],
+                             ["ELNGS", "Ellings Hall"],
+                             ["EMBAR", "Embarcadero Hall"],
+                             ["ENGR2", "Engineering II"],
+                             ["ESB", "Engineering Science"],
+                             ["GIRV", "Girvetz Hall"],
+                             ["HARDR", "Harder Stadium"],
+                             ["HFH", "Harold Frank Hall"],
+                             ["HSSB", "Humanities and Social Sciences"],
+                             ["ICA", "Intercollegiate Athletics"],
+                             ["IV", "Isla Vista Theater"],
+                             ["KERR", "Kerr Hall"],
+                             ["LIB", "Library"],
+                             ["LSB", "Life Sciences"],
+                             ["MLAB", "Music Lab"],
+                             ["MUSIC", "Music"],
+                             ["NCEAS", "NCEAS"],
+                             ["NH", "North Hall"],
+                             ["NOBLE", "Noble Hall"],
+                             ["ON", "Online"],
+                             ["PHELP", "Phelps Hall"],
+                             ["PLLOK", "Pollock Theater"],
+                             ["PSB-N", "Physical Sciences North"],
+                             ["PSB-S", "Physical Sciences South"],
+                             ["PSY-E", "Psychology East"],
+                             ["PSYCH", "Psychology"],
+                             ["RECEN", "Recreational Center"],
+                             ["RGYM", "Robertson Gym"],
+                             ["SH", "South Hall"],
+                             ["SRB", "Student Resource Building"],
+                             ["SSMS", "Social Sciences & Media Studies"],
+                             ["TD-E", "Theater & Dance East"],
+                             ["TD-W", "Theater & Dance West"],
+                             ["TRACK", "Track Field"],
+                             ["WEBB", "Webb Hall"]];
+
+export const coursesInLib = [
+{
+    "_id": {
+    "timestamp": 1684366765,
+    "date": 1684366765000
+    },
+    "courseInfo": {
+    "quarter": "20221",
+    "courseId": "CHEM    184  -1",
+    "title": "CHEM LITERATURE",
+    "description": "Lectures and exercises on the literature and other information resources of use in chemistry."
+    },
+    "section": {
+    "enrollCode": "06619",
+    "section": "0100",
+    "session": null,
+    "classClosed": null,
+    "courseCancelled": null,
+    "gradingOptionCode": null,
+    "enrolledTotal": 19,
+    "maxEnroll": 24,
+    "secondaryStatus": null,
+    "departmentApprovalRequired": false,
+    "instructorApprovalRequired": false,
+    "restrictionLevel": null,
+    "restrictionMajor": null,
+    "restrictionMajorPass": null,
+    "restrictionMinor": null,
+    "restrictionMinorPass": null,
+    "concurrentCourses": [
+        "CHEM    284  0100"
+    ],
+    "timeLocations": [
+        {
+        "room": "1312",
+        "building": "LIB",
+        "roomCapacity": null,
+        "days": " T R   ",
+        "beginTime": "14:00",
+        "endTime": "15:15"
+        }
+    ],
+    "instructors": [
+        {
+        "instructor": "HUBER C F",
+        "functionCode": "Teaching and in charge"
+        }
+    ]
+    }
+},
+{
+    "_id": {
+    "timestamp": 1684366772,
+    "date": 1684366772000
+    },
+    "courseInfo": {
+    "quarter": "20221",
+    "courseId": "CHEM    284  -1",
+    "title": "CHEMICAL LITERATURE",
+    "description": "Lectures and exercises on the literature and other   information resources of use in chemistry."
+    },
+    "section": {
+    "enrollCode": "06817",
+    "section": "0100",
+    "session": null,
+    "classClosed": null,
+    "courseCancelled": null,
+    "gradingOptionCode": null,
+    "enrolledTotal": 2,
+    "maxEnroll": 5,
+    "secondaryStatus": null,
+    "departmentApprovalRequired": false,
+    "instructorApprovalRequired": false,
+    "restrictionLevel": null,
+    "restrictionMajor": null,
+    "restrictionMajorPass": null,
+    "restrictionMinor": null,
+    "restrictionMinorPass": null,
+    "concurrentCourses": [
+        "CHEM    184  0100"
+    ],
+    "timeLocations": [
+        {
+        "room": "1312",
+        "building": "LIB",
+        "roomCapacity": null,
+        "days": " T R   ",
+        "beginTime": "14:00",
+        "endTime": "15:15"
+        }
+    ],
+    "instructors": [
+        {
+        "instructor": "HUBER C F",
+        "functionCode": "Teaching and in charge"
+        }
+    ]
+    }
+}];
+
+export const oneBuilding = [["ARTS", "Arts Building"]];
+
+export const threeBuildings = [["ELLSN", "Ellison Hall"],
+                               ["ELNGS", "Ellings Hall"],
+                               ["EMBAR", "Embarcadero Hall"]];

--- a/frontend/src/main/components/Buildings/SingleBuildingDropdown.js
+++ b/frontend/src/main/components/Buildings/SingleBuildingDropdown.js
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Form } from "react-bootstrap";
+
+const SingleBuildingDropdown = ({buildings, setBuilding, controlId, onChange = null, label="Building Name"}) => {
+    const localSearchBuilding = localStorage.getItem(controlId);
+    const [buildingState, setBuildingState] = useState(
+        // Stryker disable next-line all : not sure how to test/mock local storage
+        localSearchBuilding || "U"
+    );
+
+    const handleBuildingtoChange = (event) => {
+        localStorage.setItem(controlId, event.target.value);
+        setBuildingState(event.target.value);
+        setBuilding(event.target.value);
+        if (onChange != null) {
+            onChange(event);
+        }
+    }
+
+    return(
+        <Form.Group controlId={controlId}>
+            <Form.Label>{label}</Form.Label>
+            <Form.Control 
+                as="select" 
+                value={buildingState} 
+                onChange={handleBuildingtoChange} 
+            >
+                {buildings.map(function (object, i) {
+                    const key=`${controlId}-option-${i}`;                    
+                    return (
+                        <option 
+                            key={key} 
+                            data-testid={key}
+                            value={object[0]}
+                        >
+                            {object[1]}
+                        </option>
+                    );
+                })}
+            </Form.Control>
+        </Form.Group>
+    )
+};
+
+export default SingleBuildingDropdown;

--- a/frontend/src/stories/components/Buildings/SingleBuildingDropdown.stories.js
+++ b/frontend/src/stories/components/Buildings/SingleBuildingDropdown.stories.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+
+import SingleBuildingDropdown from "main/components/Buildings/SingleBuildingDropdown";
+import {oneBuilding, threeBuildings, allBuildings} from "fixtures/buildingFixtures";
+
+export default {
+    title: 'components/Buildings/SingleBuildingDropdown',
+    component: SingleBuildingDropdown
+};
+
+const Template = (args) => {
+    const [buildings, setBuilding] = useState(args.buildings[0]);
+
+    return (
+        < SingleBuildingDropdown 
+        buildings={buildings} 
+        setBuilding={setBuilding} 
+        controlId={"SampleControlId"}
+        label={"Building"} 
+        {...args} />
+    )
+};
+
+export const OneBuilding = Template.bind({});
+OneBuilding.args = {
+    buildings: oneBuilding
+};
+
+export const ThreeBuildings = Template.bind({});
+ThreeBuildings.args = {
+    buildings: threeBuildings
+};
+
+export const AllBuildings = Template.bind({});
+AllBuildings.args = {
+    buildings: allBuildings
+};
+

--- a/frontend/src/tests/components/Buildings/SingleBuildingDropdown.test.js
+++ b/frontend/src/tests/components/Buildings/SingleBuildingDropdown.test.js
@@ -41,7 +41,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={oneBuilding}
         building={oneBuilding}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
   });
@@ -56,13 +56,13 @@ describe("SingleBuildingDropdown tests", () => {
         ]}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const ELLSN = "ssd1-option-0";
-    const ELNGS = "ssd1-option-1";
-    const EMBAR = "ssd1-option-2";
+    const ELLSN = "sbd1-option-0";
+    const ELNGS = "sbd1-option-1";
+    const EMBAR = "sbd1-option-2";
 
     // Check that blanks are replaced with hyphens
     await waitFor(() => expect(screen.getByTestId(ELLSN).toBeInTheDocument));
@@ -71,7 +71,7 @@ describe("SingleBuildingDropdown tests", () => {
 
     // Check that the options are sorted
     // See: https://www.atkinsondev.com/post/react-testing-library-order/
-    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
+    const allOptions = screen.getAllByTestId("sbd1-option-",  { exact: false });
     for (let i = 0; i < allOptions.length - 1; i++) {
       console.log("[i]" + allOptions[i].value);
       console.log("[i+1]" + allOptions[i+1].value);
@@ -86,7 +86,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
   });
@@ -97,7 +97,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
     
@@ -116,7 +116,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
         onChange={onChange}
       />
     );
@@ -139,7 +139,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
     
@@ -152,11 +152,11 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const expectedKey = "ssd1-option-0";
+    const expectedKey = "sbd1-option-0";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 
@@ -172,7 +172,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
@@ -191,7 +191,7 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={threeBuildings}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
@@ -206,11 +206,11 @@ describe("SingleBuildingDropdown tests", () => {
         buildings={[]}
         building={building}
         setBuilding={setBuilding}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const expectedKey = "ssd1";
+    const expectedKey = "sbd1";
     expect(screen.queryByTestId(expectedKey)).toBeNull();
   });
 });

--- a/frontend/src/tests/components/Buildings/SingleBuildingDropdown.test.js
+++ b/frontend/src/tests/components/Buildings/SingleBuildingDropdown.test.js
@@ -1,0 +1,216 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom/extend-expect";
+import { useState } from "react";
+
+import SingleBuildingDropdown from "main/components/Buildings/SingleBuildingDropdown";
+import { oneBuilding } from "fixtures/buildingFixtures";
+import { threeBuildings } from "fixtures/buildingFixtures";
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: jest.fn(),
+  compareValues: jest.fn(),
+}));
+
+describe("SingleBuildingDropdown tests", () => {
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    useState.mockImplementation(jest.requireActual("react").useState);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+ })
+
+  const building = jest.fn();
+  const setBuilding = jest.fn();
+
+  test("renders without crashing on one building", () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={oneBuilding}
+        building={oneBuilding}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+  });
+
+  test("renders without crashing on three buildings", async () => {
+     render(
+      <SingleBuildingDropdown
+        buildings={[ 
+          threeBuildings[0],
+          threeBuildings[1],
+          threeBuildings[2]
+        ]}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+
+    const ELLSN = "ssd1-option-0";
+    const ELNGS = "ssd1-option-1";
+    const EMBAR = "ssd1-option-2";
+
+    // Check that blanks are replaced with hyphens
+    await waitFor(() => expect(screen.getByTestId(ELLSN).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(ELNGS).toBeInTheDocument));
+    await waitFor(() => expect(screen.getByTestId(EMBAR).toBeInTheDocument));
+
+    // Check that the options are sorted
+    // See: https://www.atkinsondev.com/post/react-testing-library-order/
+    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
+    for (let i = 0; i < allOptions.length - 1; i++) {
+      console.log("[i]" + allOptions[i].value);
+      console.log("[i+1]" + allOptions[i+1].value);
+      expect(allOptions[i].value < allOptions[i + 1].value).toBe(true);
+    }
+
+  });
+
+  test("sorts and puts hyphens in testids", () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+  });
+
+  test("when I select an object, the value changes", async () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+    
+    expect(await screen.findByLabelText("Building Name")).toBeInTheDocument();
+
+    const selectBuilding = screen.getByLabelText("Building Name");
+    userEvent.selectOptions(selectBuilding, "ELLSN");
+    expect(setBuilding).toBeCalledWith("ELLSN");
+  });
+
+  test("if I pass a non-null onChange, it gets called when the value changes", async () => {
+    const onChange = jest.fn();
+    const setBuilding = jest.fn();
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+        onChange={onChange}
+      />
+    );
+    
+    expect(await screen.findByLabelText("Building Name")).toBeInTheDocument();
+
+    const selectBuilding = screen.getByLabelText("Building Name");
+    userEvent.selectOptions(selectBuilding, "ELLSN");
+    await waitFor(() => expect(setBuilding).toBeCalledWith("ELLSN"));
+    await waitFor(() => expect(onChange).toBeCalledTimes(1));
+
+    // x.mock.calls[0][0] is the first argument of the first call to the jest.fn() mock x
+    const event = onChange.mock.calls[0][0];
+    expect(event.target.value).toBe("ELLSN");
+  });
+
+  test("default label is Building Name", async () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+    
+    expect(await screen.findByLabelText("Building Name")).toBeInTheDocument();
+  });
+
+  test("keys / testids are set correctly on options", async () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+
+    const expectedKey = "ssd1-option-0";
+    await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
+  });
+
+  test("when localstorage has a value, it is passed to useState", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => "ELLSN");
+
+    const setBuildingStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setBuildingStateSpy]);
+
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+
+    await waitFor(() => expect(useState).toBeCalledWith("ELLSN"));
+  });
+
+  test("when localstorage has no value, first element of building list is passed to useState", async () => {
+    const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    getItemSpy.mockImplementation(() => null);
+
+    const setBuildingStateSpy = jest.fn();
+    useState.mockImplementation((x) => [x, setBuildingStateSpy]);
+
+    render(
+      <SingleBuildingDropdown
+        buildings={threeBuildings}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+
+    await waitFor(() =>
+      expect(useState).toBeCalledWith(expect.objectContaining({}))
+    );
+  });
+
+  test("When no buildings, dropdown is blank", async () => {
+    render(
+      <SingleBuildingDropdown
+        buildings={[]}
+        building={building}
+        setBuilding={setBuilding}
+        controlId="ssd1"
+      />
+    );
+
+    const expectedKey = "ssd1";
+    expect(screen.queryByTestId(expectedKey)).toBeNull();
+  });
+});

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -42,7 +42,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={oneSubject}
         subject={oneSubject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
   });
@@ -57,13 +57,13 @@ describe("SingleSubjectDropdown tests", () => {
         ]}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const ART_CS = "ssd1-option-ART--CS";
-    const ANTH = "ssd1-option-ANTH";
-    const ARTHI = "ssd1-option-ARTHI";
+    const ART_CS = "sbd1-option-ART--CS";
+    const ANTH = "sbd1-option-ANTH";
+    const ARTHI = "sbd1-option-ARTHI";
 
     // Check that blanks are replaced with hyphens
     await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
@@ -72,7 +72,7 @@ describe("SingleSubjectDropdown tests", () => {
 
     // Check that the options are sorted
     // See: https://www.atkinsondev.com/post/react-testing-library-order/
-    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
+    const allOptions = screen.getAllByTestId("sbd1-option-",  { exact: false });
     for (let i = 0; i < allOptions.length - 1; i++) {
       console.log("[i]" + allOptions[i].value);
       console.log("[i+1]" + allOptions[i+1].value);
@@ -87,7 +87,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
   });
@@ -98,7 +98,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
     
@@ -115,14 +115,14 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={outOfOrderSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
     expect(await screen.findByText("Subject Area")).toBeInTheDocument();
     expect(screen.getByText("ANTH - Anthropology")).toHaveAttribute(
       "data-testid",
-      "ssd1-option-ANTH"
+      "sbd1-option-ANTH"
     );
   });
 
@@ -133,7 +133,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
         onChange={onChange}
       />
     );
@@ -156,7 +156,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
     
@@ -169,11 +169,11 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const expectedKey = "ssd1-option-ANTH";
+    const expectedKey = "sbd1-option-ANTH";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 
@@ -189,7 +189,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
@@ -208,7 +208,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
@@ -223,11 +223,11 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={[]}
         subject={subject}
         setSubject={setSubject}
-        controlId="ssd1"
+        controlId="sbd1"
       />
     );
 
-    const expectedKey = "ssd1";
+    const expectedKey = "sbd1";
     expect(screen.queryByTestId(expectedKey)).toBeNull();
   });
 });

--- a/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
+++ b/frontend/src/tests/components/Subjects/SingleSubjectDropdown.test.js
@@ -42,7 +42,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={oneSubject}
         subject={oneSubject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
   });
@@ -57,13 +57,13 @@ describe("SingleSubjectDropdown tests", () => {
         ]}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
-    const ART_CS = "sbd1-option-ART--CS";
-    const ANTH = "sbd1-option-ANTH";
-    const ARTHI = "sbd1-option-ARTHI";
+    const ART_CS = "ssd1-option-ART--CS";
+    const ANTH = "ssd1-option-ANTH";
+    const ARTHI = "ssd1-option-ARTHI";
 
     // Check that blanks are replaced with hyphens
     await waitFor(() => expect(screen.getByTestId(ART_CS).toBeInTheDocument));
@@ -72,7 +72,7 @@ describe("SingleSubjectDropdown tests", () => {
 
     // Check that the options are sorted
     // See: https://www.atkinsondev.com/post/react-testing-library-order/
-    const allOptions = screen.getAllByTestId("sbd1-option-",  { exact: false });
+    const allOptions = screen.getAllByTestId("ssd1-option-",  { exact: false });
     for (let i = 0; i < allOptions.length - 1; i++) {
       console.log("[i]" + allOptions[i].value);
       console.log("[i+1]" + allOptions[i+1].value);
@@ -87,7 +87,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
   });
@@ -98,7 +98,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
     
@@ -115,14 +115,14 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={outOfOrderSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
     expect(await screen.findByText("Subject Area")).toBeInTheDocument();
     expect(screen.getByText("ANTH - Anthropology")).toHaveAttribute(
       "data-testid",
-      "sbd1-option-ANTH"
+      "ssd1-option-ANTH"
     );
   });
 
@@ -133,7 +133,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
         onChange={onChange}
       />
     );
@@ -156,7 +156,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
     
@@ -169,11 +169,11 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
-    const expectedKey = "sbd1-option-ANTH";
+    const expectedKey = "ssd1-option-ANTH";
     await waitFor(() => expect(screen.getByTestId(expectedKey).toBeInTheDocument));
   });
 
@@ -189,7 +189,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
@@ -208,7 +208,7 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={threeSubjects}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
@@ -223,11 +223,11 @@ describe("SingleSubjectDropdown tests", () => {
         subjects={[]}
         subject={subject}
         setSubject={setSubject}
-        controlId="sbd1"
+        controlId="ssd1"
       />
     );
 
-    const expectedKey = "sbd1";
+    const expectedKey = "ssd1";
     expect(screen.queryByTestId(expectedKey)).toBeNull();
   });
 });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Scripts
+
+## getAllBuildings.py
+Returns a sorted list of all buildings where courses were held in a specific quarter.
+1. Get the login information of a Database Access User to your MongoDB database.
+2. Replace the placeholder username and password in lines 6-7.
+3. Optional: Choose a different quarter in line 26 using the YYYYQ format. Currently returns all course buildings in W22.
+4. Run the script.

--- a/scripts/getAllBuildings.py
+++ b/scripts/getAllBuildings.py
@@ -1,0 +1,39 @@
+# Kenny Tran, CS156 S23
+from pymongo.mongo_client import MongoClient
+from pymongo.server_api import ServerApi
+
+# Create a Database Access User at cloud.mongodb.com/.../security/database/users
+username = "DBUserUsernameHere"
+password = "DBUserPasswordHere"
+
+uri = f"mongodb+srv://{username}:{password}@cluster0.8jhud7s.mongodb.net/?retryWrites=true&w=majority"
+
+# Create a new client and connect to the server
+client = MongoClient(uri, server_api=ServerApi('1'))
+# Send a ping to confirm a successful connection
+try:
+    client.admin.command('ping')
+    print("Pinged your deployment. You successfully connected to MongoDB!")
+except Exception as e:
+    print(e)
+
+# Get the entire database, then find the courses
+db = client.database
+coll = db.courses
+
+# Filter by a single quarter (There might be a better filter to find all buildings)
+# For example, this does not return the new ILP building from Spring 2023.
+cursor = coll.find({ 'courseInfo.quarter': "20221" })
+
+# Add all buildings found to a set.
+# Some courses don't have a building assigned, hence the try/except block
+bldgs = set()
+for doc in cursor:
+    if len(doc['section']['timeLocations']):
+        try:
+            bldg = doc['section']['timeLocations'][0]['building']
+            bldgs.add(bldg)
+        except:
+            pass
+
+print(sorted(bldgs))


### PR DESCRIPTION
# Description
Adds the framework for a dropdown menu as well as fixtures to be used for testing in later PRs.

This is the first of 3 PRs to implement the Building-based search feature.
## Added Files
-  `buildingFixtures.js`
    - Includes a list of (most, if not) all UCSB buildings where courses can be held to be used with a dropdown menu as well as examples to be used in testing.
    - Reminder that the list of buildings is not exhaustive and includes weird "buildings" like the track field. 
    - Manually compiled with a Python script connected to the MongoDB database
-  `SingleBuildingDropdown.js` and its tests and stories
    - The code to show a user-friendly dropdown menu allowing them to choose what to search for from a list of buildings on campus.
# Storybook Links
- [SingleBuildingDropdown](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/45/storybook/?path=/docs/components-buildings-singlebuildingdropdown--all-buildings)