### PR TITLE
yl - Add index page for instructor-based search

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,7 @@ import CoursesIndexPage from "main/pages/Courses/PSCourseIndexPage";
 import CoursesCreatePage from "main/pages/Courses/PSCourseCreatePage";
 
 import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
+import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage";
 
 function App() {
 
@@ -56,6 +57,7 @@ function App() {
         }
         <Route exact path="/coursedescriptions/search" element={<CourseDescriptionIndexPage />} />
         <Route exact path="/courseovertime/search" element={<CourseOverTimeIndexPage />} />
+        <Route exact path="/courseovertime/instructorsearch" element={<CourseOverTimeInstructorIndexPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -78,6 +78,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               <NavDropdown title="Course Infos" id="appnavbar-course-infos-dropdown" data-testid="appnavbar-course-infos-dropdown">
                 <NavDropdown.Item href="/coursedescriptions/search" data-testid="appnavbar-course-descriptions-search">Course Descriptions</NavDropdown.Item>
                 <NavDropdown.Item href="/courseovertime/search" data-testid="appnavbar-course-over-time-search">Course History</NavDropdown.Item>
+                <NavDropdown.Item href="/courseovertime/instructorsearch" data-testid="appnavbar-course-over-time-instructor-search">Search by Instructor</NavDropdown.Item>
               </NavDropdown>
             </Nav>
 

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -35,7 +35,7 @@ export default function CourseOverTimeInstructorIndexPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h5>Welcome to the UCSB Course History Search!</h5>
+        <h5>Welcome to the UCSB Course Instructor Search!</h5>
         <CourseOverTimeInstructorSearchForm fetchJSON={fetchCourseOverTimeJSON} />
         <SectionsTable sections={courseJSON} />
       </div>

--- a/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.js
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import CourseOverTimeInstructorSearchForm from "main/components/BasicCourseSearch/CourseOverTimeInstructorSearchForm";
+import { useBackendMutation } from "main/utils/useBackend";
+import SectionsTable from "main/components/Sections/SectionsTable";
+
+export default function CourseOverTimeInstructorIndexPage() {
+  // Stryker disable next-line all : Can't test state because hook is internal
+  const [courseJSON, setCourseJSON] = useState([]);
+
+  const objectToAxiosParams = (query) => ({
+    url: "/api/public/courseovertime/instructorsearch",
+    params: {
+      startQtr: query.startQuarter,
+      endQtr: query.endQuarter,
+      instructor: query.instructor,
+    },
+  });
+
+  const onSuccess = (courses) => {
+    setCourseJSON(courses);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    []
+  );
+
+  async function fetchCourseOverTimeJSON(_event, query) {
+    mutation.mutate(query);
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h5>Welcome to the UCSB Course History Search!</h5>
+        <CourseOverTimeInstructorSearchForm fetchJSON={fetchCourseOverTimeJSON} />
+        <SectionsTable sections={courseJSON} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/CourseOverTimeInstructorIndexPage.stories.js
+++ b/frontend/src/stories/pages/CourseOverTimeInstructorIndexPage.stories.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage";
+import { threeSections } from "fixtures/sectionFixtures"
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
+import { ucsbSubjectsFixtures } from 'fixtures/ucsbSubjectsFixtures';
+import { apiCurrentUserFixtures } from 'fixtures/currentUserFixtures';
+
+export default {
+    title: 'pages/CourseOverTimeInstructorIndexPage',
+    component: CourseOverTimeInstructorIndexPage,
+    parameters: {
+        mockData: [
+            {
+                url: '/api/UCSBSubjects/all',
+                method: 'GET',
+                status: 200,
+                response: ucsbSubjectsFixtures.threeSubjects
+            },
+            {
+                url: '/api/public/courseovertime/instructorsearch',
+                method: 'GET',
+                status: 200,
+                response: threeSections
+            },
+            {
+                url: '/api/systemInfo',
+                method: 'GET',
+                status: 200,
+                response: systemInfoFixtures.showingBoth
+            },
+            {
+                url: '/api/currentUser',
+                method: 'GET',
+                status: 200,
+                response: apiCurrentUserFixtures.adminUser
+            },
+        ]
+    }
+};
+
+const Template = () => <CourseOverTimeInstructorIndexPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -237,4 +237,27 @@ describe("AppNavbar tests", () => {
 
         expect(await screen.findByTestId("appnavbar-course-over-time-search")).toBeInTheDocument();
     });
+
+    test("renders the Instructor Course Over Time menu correctly", async () => {
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("appnavbar-course-infos-dropdown")).toBeInTheDocument();
+        const dropdown = screen.getByTestId("appnavbar-course-infos-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+
+        expect(await screen.findByTestId("appnavbar-course-over-time-instructor-search")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseOverTime/CourseOverTimeInstructorIndexPage.test.js
@@ -1,0 +1,89 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseOverTimeInstructorIndexPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { threeSections } from "fixtures/sectionFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import userEvent from "@testing-library/user-event";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("CourseOverTimeInstructorIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    
+    beforeEach(() => {
+        axiosMock.resetHistory();
+        axiosMock
+            .onGet("/api/currentUser")
+            .reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock
+            .onGet("/api/systemInfo")
+            .reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <CourseOverTimeInstructorIndexPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+        );
+    });
+
+    test("calls UCSB Course over time search api correctly with 3 section response", async () => {
+        axiosMock.onGet("/api/UCSBSubjects/all").reply(200, allTheSubjects);
+        axiosMock
+            .onGet("/api/public/courseovertime/instructorsearch")
+            .reply(200, threeSections);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CourseOverTimeInstructorIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const selectStartQuarter = screen.getByLabelText("Start Quarter");
+        userEvent.selectOptions(selectStartQuarter, "20222");
+        const selectEndQuarter = screen.getByLabelText("End Quarter");
+        userEvent.selectOptions(selectEndQuarter, "20222");
+        const enterInstructor = screen.getByLabelText("Instructor Name")
+        userEvent.type(enterInstructor, "CONRAD");
+
+        const submitButton = screen.getByText("Submit");
+        expect(submitButton).toBeInTheDocument();
+        userEvent.click(submitButton);
+
+        axiosMock.resetHistory();
+
+        await waitFor(() => {
+            expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+        });
+
+        expect(axiosMock.history.get[0].params).toEqual({
+            startQtr: "20222",
+            endQtr: "20222",
+            instructor: "CONRAD",
+        });
+
+        expect(screen.getByText("ECE 1A")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
In this PR, we add an index page for searching by instructor, and link to it in the navbar. This change allows the user to access the instructor-based course search. This page contains the form component from PR #42, so it must be merged _after_ PR #42.

# Storybook
- Index page
  - [After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/52/storybook/?path=/docs/pages-courseovertimeinstructorindexpage--default)
- Navbar
  - [Before](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)
  - [After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/52/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)

# Screenshots
### Before
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/efdfd351-8a76-4a33-be78-9a609c2ac8e1)

### After
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/82b37d2d-5cd5-4758-8711-7e0c72b8abbd)
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/5276892d-8ed7-4d31-832d-e17e6255a9b3)
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/65eff678-2d69-40b5-b134-6fe2765014b0)

Merging this PR closes #43.