### PR TITLE
Break Two :hx - Add backend endpoint for uploading grade history data to database

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -30,6 +30,8 @@ import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
 
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJob;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
+import edu.ucsb.cs156.courses.jobs.UploadGradeDataJob;
+import edu.ucsb.cs156.courses.jobs.UploadGradeDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.TestJob;
 import edu.ucsb.cs156.courses.repositories.JobsRepository;
 import edu.ucsb.cs156.courses.services.jobs.JobService;
@@ -62,6 +64,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory updateCourseDataRangeOfQuartersSingleSubjectJobFactory;
+
+    @Autowired
+    UploadGradeDataJobFactory updateGradeDataJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -144,6 +149,13 @@ public class JobsController extends ApiController {
 
         return jobService.runAsJob(updateCourseDataRangeOfQuartersSingleSubjectJob);
     }
-
+    
+    @ApiOperation(value = "Launch Job to update grade history")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/uploadGradeData")
+    public Job launchUploadGradeData() {
+        UploadGradeDataJob updateGradeDataJob = updateGradeDataJobFactory.create();
+        return jobService.runAsJob(updateGradeDataJob);
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJob.java
@@ -1,0 +1,75 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryServiceImpl;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Optional;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@AllArgsConstructor
+public class UploadGradeDataJob implements JobContextConsumer {
+    @Getter
+    private UCSBGradeHistoryServiceImpl ucsbGradeHistoryServiceImpl;
+    @Getter
+    private GradeHistoryRepository gradeHistoryRepository;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Updating UCSB Grade History Data");
+        List<String> urls = ucsbGradeHistoryServiceImpl.getUrls();
+        GradeHistory previous = new GradeHistory();
+        List<GradeHistory> results = null;
+        for (String url : urls) {
+            results = ucsbGradeHistoryServiceImpl.getGradeData(url);
+            GradeHistory topRow = results.get(0);
+            upsertAll(gradeHistoryRepository, results);
+            logProgress(ctx, topRow, previous);
+        }
+
+        ctx.log("Finished updating UCSB Grade History Data");
+    }
+
+    private void logProgress(JobContext ctx, GradeHistory topRow, GradeHistory previous) {
+        if (!topRow.getYyyyq().equals(previous.getYyyyq())) {
+            ctx.log("Processing data for year: " + topRow.getYyyyq());
+            previous.setYyyyq(topRow.getYyyyq());
+        }
+        ctx.log("Processing data for subjectArea: " + topRow.getSubjectArea());
+    }
+
+    public static List<GradeHistory> upsertAll(
+            GradeHistoryRepository gradeHistoryRepository,
+            List<GradeHistory> gradeHistories){
+        List<GradeHistory> result = new ArrayList<GradeHistory>();
+        for (GradeHistory gradeHistory : gradeHistories) {
+            List<GradeHistory> query = gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(
+                    gradeHistory.getYyyyq(), gradeHistory.getCourse(), gradeHistory.getInstructor(),
+                    gradeHistory.getGrade());
+            if (query.size() == 0) {
+                gradeHistoryRepository.save(gradeHistory);
+                result.add(gradeHistory);
+            } else {
+                GradeHistory existing = query.get(0);
+                existing.setCount(gradeHistory.getCount());
+                existing = gradeHistoryRepository.save(existing);
+                result.add(existing);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactory.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+public class UploadGradeDataJobFactory {
+
+    @Autowired
+    UCSBGradeHistoryServiceImpl ucsbGradeHistoryServiceImpl;
+
+    @Autowired
+    GradeHistoryRepository gradeHistoryRepository;
+
+    public UploadGradeDataJob create() {
+        return new UploadGradeDataJob(
+                ucsbGradeHistoryServiceImpl,
+                gradeHistoryRepository);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -38,6 +38,7 @@ import edu.ucsb.cs156.courses.entities.User;
 
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataWithQuarterJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataJobFactory;
+import edu.ucsb.cs156.courses.jobs.UploadGradeDataJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersJobFactory;
 import edu.ucsb.cs156.courses.jobs.UpdateCourseDataRangeOfQuartersSingleSubjectJobFactory;
 
@@ -60,6 +61,9 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @MockBean
     UserRepository userRepository;
+
+    @MockBean
+    UploadGradeDataJobFactory uploadGradeDataJobFactory;
 
     @Autowired
     JobService jobService;
@@ -264,5 +268,18 @@ public class JobsControllerTests extends ControllerTestCase {
         assertNotNull(jobReturned.getStatus());
     }
 
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void admin_can_launch_upload_course_grade_data_job() throws Exception {
+        // act
+        MvcResult response = mockMvc.perform(post("/api/jobs/launch/uploadGradeData").with(csrf()))
+                .andExpect(status().isOk()).andReturn();
 
+        // assert
+        String responseString = response.getResponse().getContentAsString();
+        log.info("responseString={}", responseString);
+        Job jobReturned = objectMapper.readValue(responseString, Job.class);
+
+        assertNotNull(jobReturned.getStatus());
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactoryTests.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryServiceImpl;
+
+@RestClientTest(UploadGradeDataJobFactory.class)
+@AutoConfigureDataJpa
+public class UploadGradeDataJobFactoryTests {
+
+    @MockBean
+    GradeHistoryRepository gradeHistoryRepository;
+
+    @MockBean
+    UCSBGradeHistoryServiceImpl ucsbGradeHistoryServiceImpl;
+
+    @Autowired
+    UploadGradeDataJobFactory UploadGradeDataJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+
+        UploadGradeDataJob UploadGradeDataJob = UploadGradeDataJobFactory.create();
+
+        // Assert
+
+        assertEquals(ucsbGradeHistoryServiceImpl,UploadGradeDataJob.getUcsbGradeHistoryServiceImpl());
+        assertEquals(gradeHistoryRepository,UploadGradeDataJob.getGradeHistoryRepository());
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobTests.java
@@ -1,0 +1,183 @@
+package edu.ucsb.cs156.courses.jobs;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryServiceImpl;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@RestClientTest(UploadGradeDataJob.class)
+@AutoConfigureDataJpa
+public class UploadGradeDataJobTests {
+
+    @MockBean
+    GradeHistoryRepository gradeHistoryRepository;
+
+    @MockBean
+    UCSBGradeHistoryServiceImpl ucsbGradeHistoryServiceImpl;
+
+    @Test
+    public void test_upsertAll() {
+
+        // arrange
+
+        List<GradeHistory> gradeHistoriesToUpsert = new ArrayList<GradeHistory>();
+        GradeHistory existingOne = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build();
+        GradeHistory existingOneUpdated = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(51)
+                .build();
+        GradeHistory newOne = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   148")
+                .instructor("HOLLERER T")
+                .grade("A")
+                .count(50)
+                .build();
+
+        gradeHistoriesToUpsert.add(existingOneUpdated);
+        gradeHistoriesToUpsert.add(newOne);
+
+        when(gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   156"), eq("CONRAD P"), eq("A")))
+            .thenReturn(Arrays.asList(existingOne));
+
+        when(gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   148"), eq("HOLLERER T"), eq("A")))
+            .thenReturn(Arrays.asList());
+
+        when(gradeHistoryRepository.save(eq(existingOneUpdated)))
+            .thenReturn(existingOneUpdated);
+
+        when(gradeHistoryRepository.save(eq(newOne)))
+            .thenReturn(newOne);
+
+
+        // act
+
+        List<GradeHistory> result = UploadGradeDataJob.upsertAll(gradeHistoryRepository, gradeHistoriesToUpsert);
+
+        // assert
+
+        assertTrue(result.contains(existingOne));
+        assertTrue(result.contains(newOne));
+
+        verify(gradeHistoryRepository).findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   156"), eq("CONRAD P"), eq("A"));
+        verify(gradeHistoryRepository).findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   148"), eq("HOLLERER T"), eq("A"));
+        verify(gradeHistoryRepository).save(existingOneUpdated);
+        verify(gradeHistoryRepository).save(newOne);
+
+    }
+
+    @Test
+    void test_log_output_success() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UploadGradeDataJob uploadGradeDataJob = 
+            new UploadGradeDataJob(ucsbGradeHistoryServiceImpl,
+                gradeHistoryRepository);
+
+        List<String> mockedListOfUrls = new ArrayList<String>();
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F20/CMPSC.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F20/CMPTGCS.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/W21/CMPSC.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/W21/CMPTGCS.csv");
+
+        List<GradeHistory> gradeHistory_F20_CMPSC = new ArrayList<GradeHistory>();
+        gradeHistory_F20_CMPSC.add(
+            GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_F20_CMPTGCS = new ArrayList<GradeHistory>();
+        gradeHistory_F20_CMPTGCS.add(
+            GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPTGCS   1A")
+                .instructor("WANG R K")
+                .grade("P")
+                .count(8)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_W21_CMPSC = new ArrayList<GradeHistory>();
+        gradeHistory_W21_CMPSC.add(
+            GradeHistory.builder()
+                .yyyyq("20211")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_W21_CMPTGCS = new ArrayList<GradeHistory>();
+        gradeHistory_W21_CMPTGCS.add(
+            GradeHistory.builder()
+                .yyyyq("20211")
+                .course("CMPTGCS  20")
+                .instructor("WANG R K")
+                .grade("P")
+                .count(8)
+                .build()
+        );
+
+        when(ucsbGradeHistoryServiceImpl.getUrls()).thenReturn(mockedListOfUrls);
+        when(ucsbGradeHistoryServiceImpl.getGradeData(eq(mockedListOfUrls.get(0)))).thenReturn(gradeHistory_F20_CMPSC);
+        when(ucsbGradeHistoryServiceImpl.getGradeData(eq(mockedListOfUrls.get(1)))).thenReturn(gradeHistory_F20_CMPTGCS);
+        when(ucsbGradeHistoryServiceImpl.getGradeData(eq(mockedListOfUrls.get(2)))).thenReturn(gradeHistory_W21_CMPSC);
+        when(ucsbGradeHistoryServiceImpl.getGradeData(eq(mockedListOfUrls.get(3)))).thenReturn(gradeHistory_W21_CMPTGCS);
+
+        // Act
+
+        uploadGradeDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating UCSB Grade History Data
+            Processing data for year: 20204
+            Processing data for subjectArea: CMPSC
+            Processing data for subjectArea: CMPTGCS
+            Processing data for year: 20211
+            Processing data for subjectArea: CMPSC
+            Processing data for subjectArea: CMPTGCS
+            Finished updating UCSB Grade History Data""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+}


### PR DESCRIPTION
In this PR, we implement a backend POST endpoint to start a job, which uploads grade history for classes from Fall 2009 to Winter 2022.

# Screenshots
## Using the POST endpoint in Swagger to run the job
  ![160f725519e245fb42593f0b7d7b031](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/59790644/bc7caac2-4806-4403-8317-32afc1fa03d5)

## The job running on the jobs page
![ee7a0f242071de95c1f5e9519132faf](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/59790644/1070ca1f-86f7-49f9-8ff0-3a9304467d52)
![912aec608c5cdf72b45d3ffc5fdf6f6](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/59790644/8934d11b-03dd-4f58-957b-dd169c579a21)

## Postgres query
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/77405911/4eaaf48d-8a13-4392-877b-b5443914869b)

