### PR TITLE
nz - Added error messages to PSCourseCreatePage + tests

### DIFF
--- a/frontend/src/main/pages/Courses/PSCourseCreatePage.js
+++ b/frontend/src/main/pages/Courses/PSCourseCreatePage.js
@@ -35,7 +35,19 @@ export default function CoursesCreatePage() {
   if (isSuccess) {
     return <Navigate to="/courses/list" />
   }
+  if (mutation.isError) {
+    return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New Course</h1>
 
+        <CourseForm submitAction={onSubmit}/>
+        <p data-testid="PSCourseCreate-Error">Error: {mutation.error.response.data?.message}</p>
+
+      </div>
+    </BasicLayout>
+  )
+    }
   return (
     <BasicLayout>
       <div className="pt-2">

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -124,6 +124,6 @@ describe("CoursesCreatePage tests", () => {
 
         await screen.findByTestId("PSCourseCreate-Error")
         const PSError = screen.getByTestId("PSCourseCreate-Error");
-        expect(PSError).toBeInTheDocument;
+        expect(PSError).toBeInTheDocument();
     });
 });

--- a/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesCreatePage.test.js
@@ -97,5 +97,33 @@ describe("CoursesCreatePage tests", () => {
         expect(mockNavigate).toBeCalledWith({ "to": "/courses/list" });
     });
 
+    test("when you input incorrect information, we get an error", async () => {
 
+        const queryClient = new QueryClient();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <CoursesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId("CourseForm-psId")).toBeInTheDocument();
+        
+        const psIdField = screen.getByTestId("CourseForm-psId");
+        const enrollCdField = screen.getByTestId("CourseForm-enrollCd");
+        const submitButton = screen.getByTestId("CourseForm-submit");
+
+        fireEvent.change(psIdField, { target: { value: 13 } });
+        fireEvent.change(enrollCdField, { target: { value: '99881' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await screen.findByTestId("PSCourseCreate-Error")
+        const PSError = screen.getByTestId("PSCourseCreate-Error");
+        expect(PSError).toBeInTheDocument;
+    });
 });


### PR DESCRIPTION
In this PR, we add error messages for the PSCourseCreatePage that tell the user if they've entered and invalid Personal Schedule ID or Enroll Code