### PR TITLE
in/pc - remove +/- where not needed from basic course search and storybook for SectionTableBase

### DIFF
--- a/frontend/src/fixtures/sectionFixtures.js
+++ b/frontend/src/fixtures/sectionFixtures.js
@@ -1,48 +1,94 @@
 export const oneSection = [
-    {
-        "courseInfo": {
-          "quarter": "20221",
-          "courseId": "ECE       1A -1",
-          "title": "COMP ENGR SEMINAR",
-          "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
-        },
-        "section": {
-          "enrollCode": "12583",
-          "section": "0100",
-          "session": null,
-          "classClosed": null,
-          "courseCancelled": null,
-          "gradingOptionCode": null,
-          "enrolledTotal": 84,
-          "maxEnroll": 100,
-          "secondaryStatus": null,
-          "departmentApprovalRequired": false,
-          "instructorApprovalRequired": false,
-          "restrictionLevel": null,
-          "restrictionMajor": "+PRCME+CMPEN",
-          "restrictionMajorPass": null,
-          "restrictionMinor": null,
-          "restrictionMinorPass": null,
-          "concurrentCourses": [],
-          "timeLocations": [
-            {
-              "room": "1930",
-              "building": "BUCHN",
-              "roomCapacity": "100",
-              "days": "M      ",
-              "beginTime": "15:00",
-              "endTime": "15:50"
-            }
-          ],
-          "instructors": [
-            {
-              "instructor": "WANG L C",
-              "functionCode": "Teaching and in charge"
-            }
-          ]
-        }
-    }
+  {
+      "courseInfo": {
+        "quarter": "20221",
+        "courseId": "ECE       1A -1",
+        "title": "COMP ENGR SEMINAR",
+        "description": "Introductory seminar to expose students to a broad range of topics in computer   engineering."
+      },
+      "section": {
+        "enrollCode": "12583",
+        "section": "0100",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 84,
+        "maxEnroll": 100,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+PRCME+CMPEN",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1930",
+            "building": "BUCHN",
+            "roomCapacity": "100",
+            "days": "M      ",
+            "beginTime": "15:00",
+            "endTime": "15:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "WANG L C",
+            "functionCode": "Teaching and in charge"
+          }
+        ]
+      }
+  }
 ]
+
+export const oneLectureSectionWithNoDiscussion = [
+  {
+    "courseInfo": {
+      "quarter": "20222",
+      "courseId": "MATH    101B -1",
+      "title": "MATH SYSTEMS",
+      "description": "The theory of operations within rings and fields and the foundations of   t he real number system. Ideals, quotient rings, and factorization theorems. The history and the historical implications of these developments in mathem atical systems. Especially suitable for prospective middle and high school teachers."
+    },
+    "section": {
+      "enrollCode": "31781",
+      "section": "0100",
+      "session": null,
+      "classClosed": null,
+      "courseCancelled": null,
+      "gradingOptionCode": null,
+      "enrolledTotal": 33,
+      "maxEnroll": 45,
+      "secondaryStatus": null,
+      "departmentApprovalRequired": false,
+      "instructorApprovalRequired": false,
+      "restrictionLevel": null,
+      "restrictionMajor": "+AMATH+MATCS+MATH +MTHSC+FINMS",
+      "restrictionMajorPass": "1",
+      "restrictionMinor": null,
+      "restrictionMinorPass": null,
+      "concurrentCourses": [],
+      "timeLocations": [
+        {
+          "room": "1112",
+          "building": "GIRV",
+          "roomCapacity": "48",
+          "days": " T R   ",
+          "beginTime": "09:30",
+          "endTime": "10:45"
+        }
+      ],
+      "instructors": [
+        {
+          "instructor": "OGRAIN C M",
+          "functionCode": "Teaching and in charge"
+        }
+      ]
+    }
+  }
+];
 
 export const threeSections = [
     {

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Fragment} from "react";
 import { useTable, useGroupBy, useExpanded } from 'react-table'
 import { Table } from "react-bootstrap";
 
@@ -11,7 +11,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
 
   return (
     <Table {...getTableProps()} striped bordered hover >
-      <thead>
+      <thead key="thead">
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>
             {headerGroup.headers.map(column => (
@@ -25,11 +25,11 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
           </tr>
         ))}
       </thead>
-      <tbody {...getTableBodyProps()}>
-        {rows.map(row => {
+      <tbody {...getTableBodyProps()} key="tbody">
+        {rows.map((row,i) => {
           prepareRow(row)
           return (
-            <>
+            <Fragment key={`row-${i}`}>
             {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
@@ -37,7 +37,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    // Stryker disable all
                     style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
                     {cell.isGrouped ? (
@@ -49,7 +48,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 
-                    // Stryker restore all
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")
@@ -65,7 +63,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
 
             </tr>
             : null}
-            </>
+            </Fragment>
           )
         })}
       </tbody>

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -47,7 +47,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
                     >
-                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null}
+                    {row.subRows.length >= 2 ? row.isExpanded ? "➖ " : "➕ " : null}
                     </span>{" "}
                     {cell.render("Cell")} 
                     </>

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -49,7 +49,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 
-                    // Stryker enable all
+                    // Stryker restore all
                     // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -37,7 +37,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
+                    style={{background: cell.isGrouped ? ( "#e5fcf4" ) : ( cell.isAggregated ? "#e5fcf4" : "#effcf8" ), fontWeight: cell.isGrouped ? ( "bold" ) : ( cell.isAggregated ? "bold" : "normal" )}}
                     >
                     {cell.isGrouped ? (
                     <>

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -45,7 +45,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`} 
                     > 
-                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null} 
+                    {  ( row.subRows.length > 1  ) ? ( row.isExpanded ? "➖ " : "➕ " ) : null} 
                     </span>{" "} 
                     {cell.render("Cell")} 
                     </> 

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -38,19 +38,19 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <td
                     {...cell.getCellProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}`}
-                    // Stryker disable next-line ObjectLiteral
+                    // Stryker disable all
                     style={{background: cell.isGrouped ? "#e5fcf4" : cell.isAggregated ? "#e5fcf4" : "#effcf8", fontWeight: cell.isGrouped ? "bold" : cell.isAggregated ? "bold" : "normal"}}
                     >
-                    
                     {cell.isGrouped ? (
                     <>
                     <span {...row.getToggleRowExpandedProps()}
-                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
-                    >
-                    {row.subRows.length >= 2 ? row.isExpanded ? "➖ " : "➕ " : null}
-                    </span>{" "}
+                    data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`} 
+                    > 
+                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null} 
+                    </span>{" "} 
                     {cell.render("Cell")} 
-                    </>
+                    </> 
+                    // Stryker enable all
                     // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -33,7 +33,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
             {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
-                
                 return (
                     <td
                     {...cell.getCellProps()}

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -33,6 +33,7 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
             {row.cells[0].isGrouped || (!row.cells[0].isGrouped && row.allCells[3].value) ? 
             <tr {...row.getRowProps()}>
               {row.cells.map((cell, _index) => {
+                
                 return (
                     <td
                     {...cell.getCellProps()}
@@ -46,10 +47,11 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     <span {...row.getToggleRowExpandedProps()}
                     data-testid={`${testid}-cell-row-${cell.row.index}-col-${cell.column.id}-expand-symbols`}
                     >
-                    {row.isExpanded ? "➖ " : "➕ "}
+                    {row.subRows.length > 1 ? row.isExpanded ? "➖ " : "➕ " : null}
                     </span>{" "}
                     {cell.render("Cell")} 
                     </>
+                    // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")

--- a/frontend/src/main/components/SectionsTableBase.js
+++ b/frontend/src/main/components/SectionsTableBase.js
@@ -50,7 +50,6 @@ export default function SectionsTableBase({ columns, data, testid = "testid"}) {
                     {cell.render("Cell")} 
                     </> 
                     // Stryker restore all
-                    // the fix row.subRows.length above is used as canExpand is not working
                     ) 
                     : cell.isAggregated ? (
                       cell.render("Aggregated")

--- a/frontend/src/stories/components/SectionsTableBase.stories.js
+++ b/frontend/src/stories/components/SectionsTableBase.stories.js
@@ -1,0 +1,156 @@
+
+import React from 'react';
+import SectionsTableBase from 'main/components/SectionsTableBase';
+import { oneSection, threeSections, fiveSections, gigaSections } from 'fixtures/sectionFixtures';
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
+
+function getFirstVal(values) {
+    return values[0];
+};
+
+export default {
+    title: 'components/SectionsTableBase',
+    component: SectionsTableBase
+};
+
+const Template = (args) => {
+    return (
+        <SectionsTableBase {...args} />
+    )
+};
+
+const columns = [
+    {
+        Header: 'Quarter',
+        accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+        disableGroupBy: true,
+        id: 'quarter',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        Header: 'Course ID',
+        accessor: 'courseInfo.courseId',
+
+        Cell: ({ cell: { value } }) => value.substring(0, value.length-2)
+    },
+    {
+        Header: 'Title',
+        accessor: 'courseInfo.title',
+        disableGroupBy: true,
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+        Header: 'Is Section?',
+        accessor: (row) => isSection(row.section.section),
+        // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+        id: 'isSection',
+    },
+    {
+        Header: 'Enrolled',
+        accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+        disableGroupBy: true,
+        id: 'enrolled',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        Header: 'Location',
+        accessor: (row) => formatLocation(row.section.timeLocations),
+        disableGroupBy: true,
+        id: 'location',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        Header: 'Days',
+        accessor: (row) => formatDays(row.section.timeLocations),
+        disableGroupBy: true,
+        id: 'days',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        Header: 'Time',
+        accessor: (row) => formatTime(row.section.timeLocations),
+        disableGroupBy: true,
+        id: 'time',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },
+    {
+        Header: 'Instructor',
+        accessor: (row) => formatInstructors(row.section.instructors),
+        disableGroupBy: true,
+        id: 'instructor',
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    },        
+    {
+        Header: 'Enroll Code',
+        accessor: 'section.enrollCode', 
+        disableGroupBy: true,
+
+        aggregate: getFirstVal,
+        Aggregated: ({ cell: { value } }) => `${value}`
+    }
+];
+
+
+const testid = "SectionsTable";
+const columnsToDisplay = columns;
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    data: [],
+    columns: columnsToDisplay,
+    testid: `${testid}-empty`
+};
+
+
+export const OneSection = Template.bind({});
+
+OneSection.args = {
+    data: oneSection,
+    columns: columnsToDisplay,
+    testid: `${testid}-OneSection`
+};
+
+
+export const ThreeSections = Template.bind({});
+
+ThreeSections.args = {
+    data: threeSections,
+    columns: columnsToDisplay,
+    testid: `${testid}-ThreeSections`
+};
+
+export const FiveSections = Template.bind({});
+
+FiveSections.args = {
+    data: fiveSections,
+    columns: columnsToDisplay,
+    testid: `${testid}-FiveSections`
+};
+
+
+export const GigaSections = Template.bind({});
+
+GigaSections.args = {
+    data: gigaSections,
+    columns: columnsToDisplay,
+    testid: `${testid}-GigaSections`
+};
+
+

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -1,23 +1,133 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import SectionsTableBase from "main/components/SectionsTableBase";
+import { oneLectureSectionWithNoDiscussion, gigaSections, fiveSections } from 'fixtures/sectionFixtures';
+import { yyyyqToQyy } from "main/utils/quarterUtilities.js";
+import { convertToFraction, formatDays, formatInstructors, formatLocation, formatTime, isSection } from "main/utils/sectionUtils.js";
 
 describe("SectionsTableBase tests", () => {
 
+    function getFirstVal(values) {
+        return values[0];
+    };
+    
     const columns = [
         {
-            Header: 'Column 1',
-            accessor: 'col1', // accessor is the "key" in the data
+            Header: 'Quarter',
+            accessor: (row) => yyyyqToQyy(row.courseInfo.quarter),
+            disableGroupBy: true,
+            id: 'quarter',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
         },
         {
-            Header: 'Column 2',
-            accessor: 'col2',
-        },
-        //add groupable columns
-    ];
+            Header: 'Course ID',
+            accessor: 'courseInfo.courseId',
     
+            Cell: ({ cell: { value } }) => value.substring(0, value.length-2)
+        },
+        {
+            Header: 'Title',
+            accessor: 'courseInfo.title',
+            disableGroupBy: true,
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            Header: 'Is Section?',
+            accessor: (row) => isSection(row.section.section),
+            // Stryker disable next-line StringLiteral: this column is hidden, very hard to test
+            id: 'isSection',
+        },
+        {
+            Header: 'Enrolled',
+            accessor: (row) => convertToFraction(row.section.enrolledTotal, row.section.maxEnroll),
+            disableGroupBy: true,
+            id: 'enrolled',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Location',
+            accessor: (row) => formatLocation(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'location',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Days',
+            accessor: (row) => formatDays(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'days',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Time',
+            accessor: (row) => formatTime(row.section.timeLocations),
+            disableGroupBy: true,
+            id: 'time',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },
+        {
+            Header: 'Instructor',
+            accessor: (row) => formatInstructors(row.section.instructors),
+            disableGroupBy: true,
+            id: 'instructor',
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        },        
+        {
+            Header: 'Enroll Code',
+            accessor: 'section.enrollCode', 
+            disableGroupBy: true,
+    
+            aggregate: getFirstVal,
+            Aggregated: ({ cell: { value } }) => `${value}`
+        }
+    ];
+
     test("renders an empty table without crashing", () => {
         render(
             <SectionsTableBase columns={columns} data={[]} group={false} />
         );
+    });
+
+
+    test("renders an full table without crashing", () => {
+        render(
+            <SectionsTableBase columns={columns} data={gigaSections} group={false} />
+        );
+    });
+
+    test("renders a single lecture section correctly", async () => {
+        render(
+            <SectionsTableBase columns={columns} data={oneLectureSectionWithNoDiscussion} group={false} />
+        );
+
+        expect(await screen.queryByText("➖")).not.toBeInTheDocument();
+        expect(await screen.queryByText("➕")).not.toBeInTheDocument();
+    });
+
+
+    test("renders five sections (one with no discussion then lecture with three discussions) correctly ", async () => {
+        render(
+            <SectionsTableBase columns={columns} data={fiveSections}  group={false} />
+        );
+
+        expect(await screen.queryByText("➕")).toBeInTheDocument();
+        expect(await screen.queryByText("➖")).not.toBeInTheDocument();
+        expect(await screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId-expand-symbols")).toBeInTheDocument();
+        expect(await screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")).toHaveAttribute("style", "background: rgb(229, 252, 244); font-weight: bold;");
+
     });
 })

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -114,8 +114,8 @@ describe("SectionsTableBase tests", () => {
             <SectionsTableBase columns={columns} data={oneLectureSectionWithNoDiscussion} group={false} />
         );
 
-        expect(await screen.queryByText("➖")).not.toBeInTheDocument();
-        expect(await screen.queryByText("➕")).not.toBeInTheDocument();
+        expect(screen.queryByText("➖")).not.toBeInTheDocument();
+        expect(screen.queryByText("➕")).not.toBeInTheDocument();
     });
 
 
@@ -124,10 +124,10 @@ describe("SectionsTableBase tests", () => {
             <SectionsTableBase columns={columns} data={fiveSections}  group={false} />
         );
 
-        expect(await screen.queryByText("➕")).toBeInTheDocument();
-        expect(await screen.queryByText("➖")).not.toBeInTheDocument();
-        expect(await screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId-expand-symbols")).toBeInTheDocument();
-        expect(await screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")).toHaveAttribute("style", "background: rgb(229, 252, 244); font-weight: bold;");
+        expect(screen.getByText("➕")).toBeInTheDocument();
+        expect(screen.queryByText("➖")).not.toBeInTheDocument();
+        expect(screen.getByTestId("testid-cell-row-1-col-courseInfo.courseId-expand-symbols")).toBeInTheDocument();
+        expect(screen.getByTestId("testid-cell-row-0-col-courseInfo.courseId")).toHaveAttribute("style", "background: rgb(229, 252, 244); font-weight: bold;");
 
     });
 })

--- a/frontend/src/tests/components/SectionsTableBase.test.js
+++ b/frontend/src/tests/components/SectionsTableBase.test.js
@@ -119,7 +119,7 @@ describe("SectionsTableBase tests", () => {
     });
 
 
-    test("renders five sections (one with no discussion then lecture with three discussions) correctly ", async () => {
+    test("renders five sections (one with no discussion then lecture with three discussions) correctly", async () => {
         render(
             <SectionsTableBase columns={columns} data={fiveSections}  group={false} />
         );


### PR DESCRIPTION
Updated the Basic Course Search Page to remove the +/- button from classes that don't have any associated sections
Continuation of PR #37 with Professor Conrad's contributions
Closes issue #7 

# Contributions
Ishaan:
Updated SectionsTableBase.js to remove the button that shows +/- when there is no associated sections with it.
Fixed Professor Conrad's testing to pass lint check

Note: Used rows.subRows.length > 1 instead of canExpand/depth and other implementations since they don't work as intended.
Note: rows.subRows.length > 1 because each row has 1 empty subRow

Professor Conrad:
Added storybook for SectionsTableBase
Created tests for SectionsTableBase

# Storybook
- [Before](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/56/storybook/?path=/docs/components-sections-sectionstable--empty)
- [After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-3/prs/58/storybook/?path=/docs/components-sections-sectionstable--empty)

# Screenshots
### Before 
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/86748731/8edc6905-2021-4666-85b9-655b3db24ad1)
### After
![image](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-3/assets/86748731/db208e91-bf19-4fad-9cd9-db5f5a3ff7c7)
